### PR TITLE
Update Readme & Workflow

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Download model files
       run: |
         mkdir -p onnx
-        gh release download v0.0.1-alpha -p "onnx.zip"
+        gh release download -p "onnx.zip"
         unzip onnx.zip -d onnx/
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # Hugging Face Tokenizer to ONNX Model
 
+> ⚠️ **Looking for Full BGE-M3 Functionality?**
+> 
+> This repository demonstrates basic tokenizer conversion and generates only **dense embeddings**. If you need the complete BGE-M3 experience with **all three embedding types** (dense, sparse, and ColBERT vectors), check out our new repository:
+> 
+> **[BGE-M3 ONNX](https://github.com/yuniko-software/bge-m3-onnx)**
+> 
+> The new repository provides:
+> - All three BGE-M3 embedding types (dense, sparse, ColBERT)
+> - Production-ready implementations in C#, Java, and Python
+
 This repository demonstrates how to convert [Hugging Face](https://github.com/huggingface/transformers) tokenizers to [ONNX](https://github.com/microsoft/onnxruntime) format and use them along with embedding models in multiple programming languages.
 
 ## Key Features


### PR DESCRIPTION
### CI Workflow Updates:
* [`.github/workflows/ci-build.yml`](diffhunk://#diff-68ba9d12f6f2601fe3c9f7f9d0d02aaea52384559d6d08fae7afc941663fdfcdL45-R45): Simplified the `gh release download` command by removing the specific version tag (`v0.0.1-alpha`) to allow downloading the latest release of `onnx.zip`. 

### Documentation Enhancements:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R3-R12): Added a notice directing users to a new repository (`BGE-M3 ONNX`) for full functionality, including dense, sparse, and ColBERT embeddings, along with production-ready implementations in multiple languages.